### PR TITLE
feat: allow ignoring specific models/fields in zeal_ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ with zeal_ignore():
     # code in this block will not log/raise zeal errors
 ```
 
+If you only want to ignore a specific N+1, you can pass in a list of models/fields to ignore:
+
+```python
+with zeal_ignore([{"model": "polls.Question", "field": "options"}]):
+    # code in this block will ignore N+1s on Question.options
+```
+
 Finally, if you want to ignore N+1 alerts from a specific model/field globally, you can
 add it to your settings:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,8 @@ asgiref==3.8.1
     # via
     #   django
     #   django-stubs
+backports-tarfile==1.2.0
+    # via jaraco-context
 build==1.2.1
     # via -r requirements-dev.in
 certifi==2024.6.2
@@ -21,6 +23,8 @@ django-stubs-ext==5.0.2
     # via django-stubs
 docutils==0.21.2
     # via readme-renderer
+exceptiongroup==1.2.2
+    # via pytest
 factory-boy==3.3.0
     # via -r requirements-dev.in
 faker==26.0.0
@@ -28,7 +32,10 @@ faker==26.0.0
 idna==3.7
     # via requests
 importlib-metadata==8.0.0
-    # via twine
+    # via
+    #   build
+    #   keyring
+    #   twine
 iniconfig==2.0.0
     # via pytest
 jaraco-classes==3.4.0
@@ -96,12 +103,18 @@ six==1.16.0
     # via python-dateutil
 sqlparse==0.5.0
     # via django
+tomli==2.0.1
+    # via
+    #   build
+    #   django-stubs
+    #   pytest
 twine==5.1.1
     # via -r requirements-dev.in
 types-pyyaml==6.0.12.20240311
     # via django-stubs
 typing-extensions==4.12.2
     # via
+    #   asgiref
     #   django-stubs
     #   django-stubs-ext
 urllib3==2.2.2

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -107,20 +107,12 @@ def test_ignore_context_takes_precedence():
 
 def test_reverts_to_previous_state_when_leaving_zeal_ignore():
     # we are currently in a zeal context
-    assert _nplusone_context.get().is_in_context is True
+    initial_context = _nplusone_context.get()
     with zeal_ignore():
-        assert _nplusone_context.get().is_in_context is False
-    assert _nplusone_context.get().is_in_context is True
-
-    # if we start off *without* being in a context, that also gets reset
-    context = _nplusone_context.get()
-    context.is_in_context = None
-    _nplusone_context.set(context)
-
-    assert _nplusone_context.get().is_in_context is None
-    with zeal_ignore():
-        assert _nplusone_context.get().is_in_context is False
-    assert _nplusone_context.get().is_in_context is None
+        assert _nplusone_context.get().allowlist == [
+            {"model": "*", "field": "*"}
+        ]
+    assert _nplusone_context.get() == initial_context
 
 
 def test_resets_state_in_nested_context():
@@ -154,3 +146,54 @@ def test_resets_state_in_nested_context():
     context = _nplusone_context.get()
     assert context.ignored == {"Test:1"}
     assert list(context.counts.values()) == [1]
+
+
+def test_can_ignore_specific_models():
+    [user_1, user_2] = UserFactory.create_batch(2)
+    PostFactory.create(author=user_1)
+    PostFactory.create(author=user_2)
+
+    with zeal_ignore([{"model": "social.User", "field": "post*"}]):
+        # this will not raise, allow-listed
+        for user in User.objects.all():
+            _ = list(user.posts.all())
+
+        with pytest.raises(NPlusOneError):
+            # this is *not* allowlisted
+            for post in Post.objects.all():
+                _ = post.author
+
+    # if we ignore another field, we still raise
+    with zeal_ignore([{"model": "social.User", "field": "foobar"}]):
+        with pytest.raises(NPlusOneError):
+            for user in User.objects.all():
+                _ = list(user.posts.all())
+
+    # outside of the context, we're back to normal
+    with pytest.raises(NPlusOneError):
+        for user in User.objects.all():
+            _ = list(user.posts.all())
+
+
+def test_context_specific_allowlist_merges():
+    [user_1, user_2] = UserFactory.create_batch(2)
+    PostFactory.create(author=user_1)
+    PostFactory.create(author=user_2)
+
+    with zeal_ignore([{"model": "social.User", "field": "post*"}]):
+        # this will not raise, allow-listed
+        for user in User.objects.all():
+            _ = list(user.posts.all())
+
+        with pytest.raises(NPlusOneError):
+            # this is *not* allowlisted
+            for post in Post.objects.all():
+                _ = post.author
+
+        with zeal_ignore([{"model": "social.Post", "field": "author"}]):
+            for post in Post.objects.all():
+                _ = post.author
+
+            # this is still allowlisted
+            for user in User.objects.all():
+                _ = list(user.posts.all())


### PR DESCRIPTION
This lets you ignore specific models/fields when using `zeal_ignore`:

```python
with zeal_ignore([{"model": "polls.Question", "field": "choice*"}]):
  pass
```

Of course, you don't need to pass in an allowlist to the context:
```python
with zeal_ignore(): # equivalent to ignoring {"model": "*", "field": "*"}
  pass
```