### PR TITLE
feat: use warnings instead of logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ def baz():
 ## Configuration
 
 By default, any issues detected by zeal will raise a `ZealError`. If you'd
-rather log any detected N+1s, you can set:
+rather log any detected N+1s as warnings, you can set:
 
 ```python
 ZEAL_RAISE = False

--- a/src/zeal/listeners.py
+++ b/src/zeal/listeners.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from contextlib import contextmanager
@@ -86,7 +87,12 @@ class Listener(ABC):
         if should_error:
             raise self.error_class(message)
         else:
-            logger.warning(message)
+            warnings.warn_explicit(
+                message,
+                UserWarning,
+                filename=caller.filename,
+                lineno=caller.lineno,
+            )
 
 
 class NPlusOneListener(Listener):


### PR DESCRIPTION
when `ZEAL_RAISE = False`, we want to raise a python warning rather than logging a warning. `logging.warn` is for non-actionable warnings, while the `warnings` module is for warnings where you want the user to take some action (like fixing an N+1!)