### PR TITLE
fix: only run zeal inside context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,6 @@ DJANGO_SETTINGS_MODULE = "djangoproject.settings"
 pythonpath = ["src", "tests"]
 testpaths = ["tests"]
 addopts = "--nomigrations"
+markers = [
+    "nozeal: disable the auto-setup of zeal in a test",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,9 @@ from zeal import zeal_context
 
 
 @pytest.fixture(scope="function", autouse=True)
-def use_zeal():
-    with zeal_context():
+def use_zeal(request):
+    if "nozeal" in request.keywords:
         yield
+    else:
+        with zeal_context():
+            yield

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -221,3 +221,21 @@ def test_context_specific_allowlist_merges():
             # this is still allowlisted
             for user in User.objects.all():
                 _ = list(user.posts.all())
+
+
+# other tests automatically run in a zeal context, so we need to disable
+# that here.
+@pytest.mark.nozeal
+def test_does_not_run_outside_of_context():
+    [user_1, user_2] = UserFactory.create_batch(2)
+    PostFactory.create(author=user_1)
+    PostFactory.create(author=user_2)
+
+    # this should not raise since we are outside of a zeal context
+    for user in User.objects.all():
+        _ = list(user.posts.all())
+
+    with zeal_context(), pytest.raises(NPlusOneError):
+        # this should raise since we are inside a zeal context
+        for user in User.objects.all():
+            _ = list(user.posts.all())


### PR DESCRIPTION
fixes #19. zeal should only fire after calling `setup()` or inside a `zeal_context()` block.