### PR TITLE
perf: don't load context in callstack

### DIFF
--- a/src/zeal/util.py
+++ b/src/zeal/util.py
@@ -16,7 +16,7 @@ def get_stack() -> list[inspect.FrameInfo]:
     """
     return [
         frame
-        for frame in inspect.stack()[1:]
+        for frame in inspect.stack(context=0)[1:]
         if not any(pattern in frame.filename for pattern in PATTERNS)
     ]
 

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -52,7 +52,9 @@ def test_can_exclude_with_allowlist(settings):
     for user in User.objects.all():
         _ = list(user.posts.all())
 
-    with pytest.raises(NPlusOneError):
+    with pytest.raises(
+        NPlusOneError, match=re.escape("N+1 detected on Post.author")
+    ):
         for post in Post.objects.all():
             _ = post.author
 
@@ -68,7 +70,9 @@ def test_can_use_fnmatch_pattern_in_allowlist_model(settings):
     for user in User.objects.all():
         _ = list(user.posts.all())
 
-    with pytest.raises(NPlusOneError):
+    with pytest.raises(
+        NPlusOneError, match=re.escape("N+1 detected on Post.author")
+    ):
         for post in Post.objects.all():
             _ = post.author
 
@@ -84,7 +88,9 @@ def test_can_use_fnmatch_pattern_in_allowlist_field(settings):
     for user in User.objects.all():
         _ = list(user.posts.all())
 
-    with pytest.raises(NPlusOneError):
+    with pytest.raises(
+        NPlusOneError, match=re.escape("N+1 detected on Post.author")
+    ):
         for post in Post.objects.all():
             _ = post.author
 
@@ -158,19 +164,25 @@ def test_can_ignore_specific_models():
         for user in User.objects.all():
             _ = list(user.posts.all())
 
-        with pytest.raises(NPlusOneError):
+        with pytest.raises(
+            NPlusOneError, match=re.escape("N+1 detected on Post.author")
+        ):
             # this is *not* allowlisted
             for post in Post.objects.all():
                 _ = post.author
 
     # if we ignore another field, we still raise
     with zeal_ignore([{"model": "social.User", "field": "foobar"}]):
-        with pytest.raises(NPlusOneError):
+        with pytest.raises(
+            NPlusOneError, match=re.escape("N+1 detected on User.posts")
+        ):
             for user in User.objects.all():
                 _ = list(user.posts.all())
 
     # outside of the context, we're back to normal
-    with pytest.raises(NPlusOneError):
+    with pytest.raises(
+        NPlusOneError, match=re.escape("N+1 detected on User.posts")
+    ):
         for user in User.objects.all():
             _ = list(user.posts.all())
 
@@ -185,7 +197,9 @@ def test_context_specific_allowlist_merges():
         for user in User.objects.all():
             _ = list(user.posts.all())
 
-        with pytest.raises(NPlusOneError):
+        with pytest.raises(
+            NPlusOneError, match=re.escape("N+1 detected on Post.author")
+        ):
             # this is *not* allowlisted
             for post in Post.objects.all():
                 _ = post.author

--- a/tests/test_nplusones.py
+++ b/tests/test_nplusones.py
@@ -467,7 +467,9 @@ def test_works_in_web_requests(client):
     [user_1, user_2] = UserFactory.create_batch(2)
     ProfileFactory.create(user=user_1)
     ProfileFactory.create(user=user_2)
-    with pytest.raises(NPlusOneError):
+    with pytest.raises(
+        NPlusOneError, match=re.escape(r"N+1 detected on User.profile")
+    ):
         response = client.get("/users/")
 
     # but multiple requests work fine


### PR DESCRIPTION
Zeal loads the call stack whenever a row is loaded from the DB. It does this to help prevent false positives for to enable the `ZEAL_SHOW_ALL_CALLERS` functionality.

Before, we were loading the call stack with `inspect.stack()`, which loads the surrounding context (i.e. lines of code) around each call. We don't actually need this, so we can instead use `inspect.stack(0)`, which skips loading the context.

In my testing, this makes things twice as fast.

Fixes #24