### PR TITLE
Add support sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,23 @@ ZEAL_ALLOWLIST = [
 ]
 ```
 
+## Sentry supporting
+
+If you want send message to sentry, you can set
+
+```python
+ZEAL_RAISE_IN_SENTRY = True
+```
+
+Note: if you set this option, errors won't raise locally, you should do it for production development. It has been done to avoid duplicate errors message for sentry.
+
+Also you can set level log message for sentry
+
+```python
+ZEAL_TYPE_MESSAGE_FOR_SENTRY = "info"
+```
+List of available [levels](https://github.com/getsentry/sentry-python/blob/24e5359580374ba474cbb2fb2837ed4c8a29cae6/sentry_sdk/_types.py#L31), take a attention, if you'll specify level not including on the list, level will be as error,
+
 ## Debugging N+1s
 
 By default, zeal's alerts will tell you the line of your code that executed the same query

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -8,3 +8,4 @@ pyright
 build
 twine
 pytest-random-order
+sentry-sdk

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,9 +9,15 @@ backports-tarfile==1.2.0
 build==1.2.1
     # via -r requirements-dev.in
 certifi==2024.6.2
-    # via requests
+    # via
+    #   requests
+    #   sentry-sdk
+cffi==1.17.1
+    # via cryptography
 charset-normalizer==3.3.2
     # via requests
+cryptography==43.0.3
+    # via secretstorage
 django==4.2.13
     # via
     #   -r requirements-dev.in
@@ -44,6 +50,10 @@ jaraco-context==5.3.0
     # via keyring
 jaraco-functools==4.0.1
     # via keyring
+jeepney==0.8.0
+    # via
+    #   keyring
+    #   secretstorage
 keyring==25.2.1
     # via twine
 markdown-it-py==3.0.0
@@ -66,6 +76,8 @@ pkginfo==1.10.0
     # via twine
 pluggy==1.5.0
     # via pytest
+pycparser==2.22
+    # via cffi
 pygments==2.18.0
     # via
     #   readme-renderer
@@ -99,11 +111,15 @@ rich==13.7.1
     # via twine
 ruff==0.5.0
     # via -r requirements-dev.in
+secretstorage==3.3.3
+    # via keyring
+sentry-sdk==2.18.0
+    # via -r requirements-dev.in
 six==1.16.0
     # via python-dateutil
 sqlparse==0.5.0
     # via django
-tomli==2.0.1
+tomli==2.0.2
     # via
     #   build
     #   django-stubs
@@ -120,6 +136,7 @@ typing-extensions==4.12.2
 urllib3==2.2.2
     # via
     #   requests
+    #   sentry-sdk
     #   twine
 zipp==3.19.2
     # via importlib-metadata

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[options.extras_require]
+sentry = sentry-sdk;


### PR DESCRIPTION
Hi, I suggest add support for sending message to Sentry. This is necessary so that errors are simply displayed in Sentry and do not interfere with the work of the API in production or development environment. I will continue next week, but I'm ready to discuss