### PR TITLE
Add signal for detecting N+1 queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,17 @@ with zeal_ignore([{"model": "polls.Question", "field": "options"}]):
     # code in this block will ignore N+1s on Question.options
 ```
 
+If you want to listen to N+1 exceptions globally and do something with them, you can listen to the Django signal that zeal emits
+
+```python
+from zeal.signals import nplusone_detected
+from django.dispatch import receiver
+
+@receiver(nplusone_detected)
+def handle_nplusone(sender, exception):
+    # do something
+```
+
 Finally, if you want to ignore N+1 alerts from a specific model/field globally, you can
 add it to your settings:
 
@@ -194,6 +205,7 @@ ZEAL_ALLOWLIST = [
     {"model": "polls.Question"},
 ]
 ```
+
 
 ## Debugging N+1s
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -8,3 +8,4 @@ pyright
 build
 twine
 pytest-random-order
+pytest-mock

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,8 +10,12 @@ build==1.2.1
     # via -r requirements-dev.in
 certifi==2024.6.2
     # via requests
+cffi==1.17.1
+    # via cryptography
 charset-normalizer==3.3.2
     # via requests
+cryptography==43.0.3
+    # via secretstorage
 django==4.2.13
     # via
     #   -r requirements-dev.in
@@ -44,6 +48,10 @@ jaraco-context==5.3.0
     # via keyring
 jaraco-functools==4.0.1
     # via keyring
+jeepney==0.8.0
+    # via
+    #   keyring
+    #   secretstorage
 keyring==25.2.1
     # via twine
 markdown-it-py==3.0.0
@@ -66,6 +74,8 @@ pkginfo==1.10.0
     # via twine
 pluggy==1.5.0
     # via pytest
+pycparser==2.22
+    # via cffi
 pygments==2.18.0
     # via
     #   readme-renderer
@@ -78,8 +88,11 @@ pytest==8.2.2
     # via
     #   -r requirements-dev.in
     #   pytest-django
+    #   pytest-mock
     #   pytest-random-order
 pytest-django==4.8.0
+    # via -r requirements-dev.in
+pytest-mock==3.14.0
     # via -r requirements-dev.in
 pytest-random-order==1.1.1
     # via -r requirements-dev.in
@@ -99,11 +112,13 @@ rich==13.7.1
     # via twine
 ruff==0.5.0
     # via -r requirements-dev.in
+secretstorage==3.3.3
+    # via keyring
 six==1.16.0
     # via python-dateutil
 sqlparse==0.5.0
     # via django
-tomli==2.0.1
+tomli==2.0.2
     # via
     #   build
     #   django-stubs

--- a/src/zeal/listeners.py
+++ b/src/zeal/listeners.py
@@ -16,6 +16,7 @@ from zeal.util import get_caller, get_stack
 
 from .constants import ALL_APPS
 from .errors import NPlusOneError, ZealConfigError, ZealError
+from .signals import nplusone_detected
 
 
 class QuerySource(TypedDict):
@@ -181,6 +182,20 @@ class NPlusOneListener(Listener):
             return settings.ZEAL_NPLUSONE_THRESHOLD
         else:
             return 2
+
+    def _alert(
+        self,
+        model: type[models.Model],
+        field: str,
+        message: str,
+        calls: list[list[inspect.FrameInfo]],
+    ):
+        super()._alert(model, field, message, calls)
+        nplusone_detected.send(
+            sender=self,
+            exception=self.error_class(message),
+        )
+
 
 
 n_plus_one_listener = NPlusOneListener()

--- a/src/zeal/signals.py
+++ b/src/zeal/signals.py
@@ -1,0 +1,3 @@
+from django.dispatch import Signal
+
+nplusone_detected = Signal()

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,30 @@
+import pytest
+import pytest_django
+import pytest_mock
+from djangoproject.social import models
+from zeal import errors
+
+from . import factories
+
+pytestmark = pytest.mark.django_db
+
+
+def test_signal_send_message(
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: pytest_mock.MockerFixture,
+    settings: pytest_django.fixtures.SettingsWrapper,
+):
+    """Test signal send message after detecting N+1 query."""
+    settings.ZEAL_RAISE = False
+    patched_signal = mocker.patch(
+        "zeal.listeners.nplusone_detected.send",
+    )
+    user_1, user_2 = factories.UserFactory.create_batch(2)
+    factories.PostFactory.create(author=user_1)
+    factories.PostFactory.create(author=user_2)
+    _ = [
+        post.author.username
+        for post in models.Post.objects.all()
+    ]
+    patched_signal.assert_called_once()
+


### PR DESCRIPTION
Hi, I added signal `nplusone_detected` to handle exception, for example send it to sentry or other error tracking systems