### PR TITLE
fix: allow zeal_ignore even when zeal is disabled

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,6 @@ asgiref==3.8.1
     # via
     #   django
     #   django-stubs
-backports-tarfile==1.2.0
-    # via jaraco-context
 build==1.2.1
     # via -r requirements-dev.in
 certifi==2024.6.2
@@ -25,8 +23,6 @@ django-stubs-ext==5.0.2
     # via django-stubs
 docutils==0.21.2
     # via readme-renderer
-exceptiongroup==1.2.2
-    # via pytest
 factory-boy==3.3.0
     # via -r requirements-dev.in
 faker==26.0.0
@@ -36,11 +32,7 @@ filelock==3.16.1
 idna==3.7
     # via requests
 importlib-metadata==8.5.0
-    # via
-    #   build
-    #   keyring
-    #   pytest-codspeed
-    #   twine
+    # via twine
 iniconfig==2.0.0
     # via pytest
 jaraco-classes==3.4.0
@@ -114,25 +106,20 @@ rich==13.9.4
     #   twine
 ruff==0.5.0
     # via -r requirements-dev.in
+setuptools==75.8.0
+    # via pytest-codspeed
 six==1.16.0
     # via python-dateutil
 sqlparse==0.5.0
     # via django
-tomli==2.1.0
-    # via
-    #   build
-    #   django-stubs
-    #   pytest
 twine==5.1.1
     # via -r requirements-dev.in
 types-pyyaml==6.0.12.20240311
     # via django-stubs
 typing-extensions==4.12.2
     # via
-    #   asgiref
     #   django-stubs
     #   django-stubs-ext
-    #   rich
 urllib3==2.2.2
     # via
     #   requests

--- a/src/zeal/listeners.py
+++ b/src/zeal/listeners.py
@@ -229,9 +229,10 @@ def zeal_context():
 
 @contextmanager
 def zeal_ignore(allowlist: Optional[list[AllowListEntry]] = None):
+    old_context = _nplusone_context.get()
     if allowlist is None:
         allowlist = [{"model": "*", "field": "*"}]
-    else:
+    elif old_context.enabled:
         _validate_allowlist(allowlist)
 
     old_context = _nplusone_context.get()

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -318,3 +318,9 @@ def test_validates_related_name_field_names():
     # User.blocked is a M2M field with an auto-generated related name (user_set)
     with zeal_ignore([{"model": "social.User", "field": "user_set"}]):
         pass
+
+
+@pytest.mark.nozeal
+def test_handles_zeal_ignore_when_disabled():
+    with zeal_ignore([{"model": "social.User", "field": "post"}]):
+        pass


### PR DESCRIPTION
We discovered that when running with zeal installed but disabled (i.e. not in `INSTALLED_APPS`), then using `zeal_ignore` with a specific allowlist would break. This PR fixes that.