### PR TITLE
ci: add Django 6.0 to test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,13 +11,20 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        django-version: ["4.2", "5.0"]
+        django-version: ["4.2", "5.0", "6.0"]
         exclude:
           # django 5 requires python >=3.10
           - python-version: 3.9
             django-version: 5.0
           - python-version: 3.9
             django-version: 5.1
+          # django 6 requires python >=3.12
+          - python-version: 3.9
+            django-version: 6.0
+          - python-version: 3.10
+            django-version: 6.0
+          - python-version: 3.11
+            django-version: 6.0
     name: Test (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }})
 
     steps:


### PR DESCRIPTION
## Summary
- Django 6.0 was released 2025-12-03; add it to the CI matrix so we actually test against it
- Excluded for Python 3.9/3.10/3.11 since Django 6.0 requires Python >=3.12

## Test plan
- [x] New `Test (Python 3.12, Django 6.0)` job appears in CI and passes
- [x] Existing 4.2 / 5.0 jobs still run

🤖 Generated with [Claude Code](https://claude.com/claude-code)