### PR TITLE
fix: rename "get"->"get()" and allow it in allowed fields

### DIFF
--- a/src/zeal/listeners.py
+++ b/src/zeal/listeners.py
@@ -56,6 +56,9 @@ def _validate_allowlist(allowlist: list[AllowListEntry]):
         if any(char in entry["field"] for char in fnmatch_chars):
             continue
 
+        if entry["field"] == "get":
+            continue
+
         if entry["field"] not in ALL_APPS[entry["model"]]:
             raise ZealConfigError(
                 f"Field '{entry['field']}' not found on '{entry['model']}'"

--- a/src/zeal/listeners.py
+++ b/src/zeal/listeners.py
@@ -56,7 +56,7 @@ def _validate_allowlist(allowlist: list[AllowListEntry]):
         if any(char in entry["field"] for char in fnmatch_chars):
             continue
 
-        if entry["field"] == "get":
+        if entry["field"] == "get()":
             continue
 
         if entry["field"] not in ALL_APPS[entry["model"]]:

--- a/src/zeal/patch.py
+++ b/src/zeal/patch.py
@@ -539,7 +539,11 @@ def patch_global_queryset():
                 not getattr(qs, "__zeal_patched", False)
                 and not _in_gfk_get.get()
             ):
-                n_plus_one_listener.notify(qs.model, "get", instance_key=None)
+                n_plus_one_listener.notify(
+                    qs.model,
+                    "get()",
+                    instance_key=None,
+                )
             ret = func(*args, **kwargs)
             n_plus_one_listener.ignore(get_instance_key(ret))
             return ret

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -287,6 +287,13 @@ def test_allows_fnmatch_in_global_allowlist(settings):
         pass
 
 
+@pytest.mark.nozeal
+def test_allows_get_in_global_allowlist(settings):
+    settings.ZEAL_ALLOWLIST = [{"model": "social.User", "field": "get"}]
+    with zeal_context():
+        pass
+
+
 def test_validates_local_allowlist_model_name():
     with pytest.raises(
         ZealConfigError,
@@ -308,6 +315,18 @@ def test_validates_local_allowlist_field_name():
 def test_allows_fnmatch_in_local_allowlist():
     with zeal_ignore([{"model": "social.U[sb]er", "field": "p?st"}]):
         pass
+
+
+def test_allows_get_in_local_allowlist():
+    with zeal_ignore([{"model": "social.User", "field": "get"}]):
+        pass
+
+
+def test_get_allowlist_suppresses_nplusone_on_get():
+    users = UserFactory.create_batch(2)
+    with zeal_ignore([{"model": "social.User", "field": "get"}]):
+        for user in users:
+            _ = User.objects.get(pk=user.pk)
 
 
 def test_validates_related_name_field_names():

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -289,7 +289,7 @@ def test_allows_fnmatch_in_global_allowlist(settings):
 
 @pytest.mark.nozeal
 def test_allows_get_in_global_allowlist(settings):
-    settings.ZEAL_ALLOWLIST = [{"model": "social.User", "field": "get"}]
+    settings.ZEAL_ALLOWLIST = [{"model": "social.User", "field": "get()"}]
     with zeal_context():
         pass
 
@@ -318,13 +318,13 @@ def test_allows_fnmatch_in_local_allowlist():
 
 
 def test_allows_get_in_local_allowlist():
-    with zeal_ignore([{"model": "social.User", "field": "get"}]):
+    with zeal_ignore([{"model": "social.User", "field": "get()"}]):
         pass
 
 
 def test_get_allowlist_suppresses_nplusone_on_get():
     users = UserFactory.create_batch(2)
-    with zeal_ignore([{"model": "social.User", "field": "get"}]):
+    with zeal_ignore([{"model": "social.User", "field": "get()"}]):
         for user in users:
             _ = User.objects.get(pk=user.pk)
 

--- a/tests/test_nplusones.py
+++ b/tests/test_nplusones.py
@@ -497,7 +497,7 @@ def test_works_in_web_requests(client):
 def test_detects_nplusone_on_get():
     users = UserFactory.create_batch(2)
     with pytest.raises(
-        NPlusOneError, match=re.escape("N+1 detected on social.User.get")
+        NPlusOneError, match=re.escape("N+1 detected on social.User.get()")
     ):
         for user in users:
             _ = User.objects.get(pk=user.pk)
@@ -811,8 +811,6 @@ def test_no_false_positive_when_accessing_generic_foreign_key_twice():
         # 1 query for the tag itself, 1 for the User via GFK,
         # plus ContentType lookups (cached after first).
         gfk_queries = [
-            q
-            for q in ctx.captured_queries
-            if '"social_user"' in q["sql"]
+            q for q in ctx.captured_queries if '"social_user"' in q["sql"]
         ]
         assert len(gfk_queries) == 1


### PR DESCRIPTION
#53 introduced N+1 protection on `get` calls, but those are not directly ignorable from allowlist, since they're not really real fields. This add an exception to the rule for that.

Follow-up proposal: maybe the "field" should be called `get()` instead, in order to avoid all collisions?