### PR TITLE
ci: enable Sigstore attestations on PyPI publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,3 +34,5 @@ jobs:
         run: python3 -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          attestations: true


### PR DESCRIPTION
## Summary
Explicitly enable `attestations: true` on the PyPI publish step so each published wheel/sdist gets a [Sigstore-signed attestation](https://docs.pypi.org/attestations/) linking it to this workflow run. Anyone can verify a release came from this exact workflow at this exact ref (\`uv publish --check-attestations\` and similar).

Recent versions of \`pypa/gh-action-pypi-publish\` default to \`true\`, but setting it explicitly prevents a silent regression if the action ever flips the default.

No new permissions required — uses the existing \`id-token: write\` that's already there for trusted publishing.

## Test plan
- [ ] Next release publishes successfully and an attestation appears on the PyPI release page
- [ ] No new permission prompts or workflow failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)