### PR TITLE
feat: detect N+1 on GenericRelation accessors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ cython_debug/
 
 .ruff_cache/
 .codspeed/
+
+# Brainstorming specs and implementation plans (local scratch only)
+docs/superpowers/

--- a/src/zeal/patch.py
+++ b/src/zeal/patch.py
@@ -385,6 +385,56 @@ def patch_many_to_many_descriptor():
     )
 
 
+def patch_generic_related_manager():
+    from django.contrib.contenttypes.fields import create_generic_related_manager
+
+    def parser(context: QuerysetContext) -> QuerySource:
+        assert (
+            "manager_call_args" in context
+            and context["manager_call_args"] is not None
+            and "rel" in context["manager_call_args"]
+        )
+        assert "instance" in context and context["instance"] is not None
+        rel = context["manager_call_args"]["rel"]
+        instance = context["instance"]
+        return {
+            "model": instance.__class__,
+            "field": rel.field.name,
+            "instance_key": get_instance_key(instance),
+        }
+
+    def patched_create_generic_related_manager(*args, **kwargs):
+        manager_call_args = inspect.getcallargs(
+            create_generic_related_manager, *args, **kwargs
+        )
+        manager = create_generic_related_manager(*args, **kwargs)
+
+        def patch_init_method(func):
+            @functools.wraps(func)
+            def wrapper(self, instance=None):
+                self.get_queryset = patch_queryset_function(
+                    self.get_queryset,
+                    parser,
+                    context={
+                        "args": None,
+                        "kwargs": None,
+                        "manager_call_args": manager_call_args,
+                        "instance": instance,
+                    },
+                )
+                return func(self, instance)
+
+            return wrapper
+
+        manager.__init__ = patch_init_method(manager.__init__)  # type: ignore
+        return manager
+
+    patch_module_function(
+        create_generic_related_manager,
+        patched_create_generic_related_manager,
+    )
+
+
 def patch_deferred_attribute():
     def patched_check_parent_chain(func):
         @functools.wraps(func)
@@ -473,5 +523,6 @@ def patch():
     patch_reverse_many_to_one_descriptor()
     patch_reverse_one_to_one_descriptor()
     patch_many_to_many_descriptor()
+    patch_generic_related_manager()
     patch_deferred_attribute()
     patch_global_queryset()

--- a/src/zeal/patch.py
+++ b/src/zeal/patch.py
@@ -41,8 +41,10 @@ class QuerysetContext(TypedDict):
     args: Optional[Any]
     kwargs: Optional[Any]
 
-    # This is only used for many-to-many relations. It contains the call args
-    # when `create_forward_many_to_many_manager` is called.
+    # Used by managers built via factory functions like
+    # create_forward_many_to_many_manager, create_reverse_many_to_one_manager,
+    # and create_generic_related_manager. Contains the call args captured at
+    # factory invocation time.
     manager_call_args: Optional[dict[str, Any]]
 
     # used by ReverseManyToOne. a django model instance.

--- a/src/zeal/patch.py
+++ b/src/zeal/patch.py
@@ -388,7 +388,9 @@ def patch_many_to_many_descriptor():
 
 
 def patch_generic_related_manager():
-    from django.contrib.contenttypes.fields import create_generic_related_manager
+    from django.contrib.contenttypes.fields import (
+        create_generic_related_manager,
+    )
 
     def parser(context: QuerysetContext) -> QuerySource:
         assert (

--- a/src/zeal/patch.py
+++ b/src/zeal/patch.py
@@ -415,6 +415,7 @@ def patch_generic_related_manager():
 
         def patch_init_method(func):
             @functools.wraps(func)
+            # instance=None mirrors GenericRelatedObjectManager.__init__'s signature
             def wrapper(self, instance=None):
                 self.get_queryset = patch_queryset_function(
                     self.get_queryset,

--- a/src/zeal/patch.py
+++ b/src/zeal/patch.py
@@ -432,6 +432,16 @@ def patch_generic_related_manager():
             return wrapper
 
         manager.__init__ = patch_init_method(manager.__init__)  # type: ignore
+
+        def notify_fn(self, instance):
+            n_plus_one_listener.notify(
+                instance.__class__,
+                manager_call_args["rel"].field.name,
+                instance_key=get_instance_key(instance),
+            )
+
+        _wrap_prefetch(manager, notify_fn)
+
         return manager
 
     patch_module_function(

--- a/tests/djangoproject/social/models.py
+++ b/tests/djangoproject/social/models.py
@@ -1,3 +1,8 @@
+from django.contrib.contenttypes.fields import (
+    GenericForeignKey,
+    GenericRelation,
+)
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
 
@@ -9,6 +14,8 @@ class User(models.Model):
     # note that there's no related_name set here, because we want to
     # test that case too.
     blocked = models.ManyToManyField("user")
+
+    tags = GenericRelation("Tag")
 
     followers: models.Manager["User"]
     user_set: models.Manager["User"]
@@ -30,3 +37,10 @@ class Post(models.Model):
         User, on_delete=models.CASCADE, related_name="posts"
     )
     text = models.TextField()
+
+
+class Tag(models.Model):
+    label = models.TextField()
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
+    object_id = models.PositiveIntegerField()
+    obj = GenericForeignKey()

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,7 +1,7 @@
 from typing import Generic, TypeVar
 
 import factory
-from djangoproject.social.models import Post, Profile, User
+from djangoproject.social.models import Post, Profile, Tag, User
 
 T = TypeVar("T")
 
@@ -31,3 +31,10 @@ class PostFactory(BaseFactory[Post]):
 
     class Meta:  # type: ignore
         model = Post
+
+
+class TagFactory(BaseFactory[Tag]):
+    label = factory.Faker("word")
+
+    class Meta:  # type: ignore
+        model = Tag

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -33,6 +33,7 @@ class PostFactory(BaseFactory[Post]):
         model = Post
 
 
+# Pass obj=<instance> when calling; content_type and object_id are derived from it.
 class TagFactory(BaseFactory[Tag]):
     label = factory.Faker("word")
 

--- a/tests/test_nplusones.py
+++ b/tests/test_nplusones.py
@@ -583,6 +583,20 @@ class TestPrefetchRelatedObjects:
             for user in users:
                 prefetch_related_objects([user], "followers")
 
+    def test_generic_relation_per_instance_is_n_plus_one(self):
+        from djangoproject.social.models import Tag
+
+        users = UserFactory.create_batch(2)
+        for u in users:
+            Tag.objects.create(obj=u, label="x")
+        users = list(User.objects.all())
+        with pytest.raises(
+            NPlusOneError,
+            match=re.escape("N+1 detected on social.User.tags"),
+        ):
+            for user in users:
+                prefetch_related_objects([user], "tags")
+
     def test_per_instance_in_iterator_loop_is_n_plus_one(self):
         users = UserFactory.create_batch(2)
         for u in users:

--- a/tests/test_nplusones.py
+++ b/tests/test_nplusones.py
@@ -611,3 +611,19 @@ class TestPrefetchRelatedObjects:
 
         prefetch_one(User.objects.get(pk=user_1.pk))
         prefetch_one(User.objects.get(pk=user_2.pk))
+
+
+def test_detects_nplusone_in_generic_relation():
+    from djangoproject.social.models import Tag
+
+    [user_1, user_2] = UserFactory.create_batch(2)
+    Tag.objects.create(obj=user_1, label="a")
+    Tag.objects.create(obj=user_2, label="b")
+    with pytest.raises(
+        NPlusOneError, match=re.escape("N+1 detected on social.User.tags")
+    ):
+        for user in User.objects.all():
+            _ = list(user.tags.all())
+
+    for user in User.objects.prefetch_related("tags").all():
+        _ = list(user.tags.all())

--- a/tests/test_nplusones.py
+++ b/tests/test_nplusones.py
@@ -673,3 +673,15 @@ def test_no_false_positive_when_loading_single_object_generic_relation():
         _ = list(user_1.tags.all())
         _ = list(user_2.tags.all())
         assert len(ctx.captured_queries) == 4
+
+
+def test_zeal_ignore_works_for_generic_relation():
+    from djangoproject.social.models import Tag
+
+    [user_1, user_2] = UserFactory.create_batch(2)
+    Tag.objects.create(obj=user_1, label="a")
+    Tag.objects.create(obj=user_2, label="b")
+
+    with zeal_ignore([{"model": "social.User", "field": "tags"}]):
+        for user in User.objects.all():
+            _ = list(user.tags.all())

--- a/tests/test_nplusones.py
+++ b/tests/test_nplusones.py
@@ -685,3 +685,16 @@ def test_zeal_ignore_works_for_generic_relation():
     with zeal_ignore([{"model": "social.User", "field": "tags"}]):
         for user in User.objects.all():
             _ = list(user.tags.all())
+
+
+def test_no_false_positive_when_calling_generic_relation_twice():
+    from djangoproject.social.models import Tag
+
+    user = UserFactory.create()
+    Tag.objects.create(obj=user, label="a")
+
+    with zeal_context(), CaptureQueriesContext(connection) as ctx:
+        queryset = user.tags.all()
+        list(queryset)  # evaluate queryset once
+        list(queryset)  # evaluate again (cached)
+        assert len(ctx.captured_queries) == 1

--- a/tests/test_nplusones.py
+++ b/tests/test_nplusones.py
@@ -643,3 +643,33 @@ def test_detects_nplusone_in_generic_relation_iterator():
 
     for user in User.objects.prefetch_related("tags").iterator(chunk_size=2):
         _ = list(user.tags.all())
+
+
+def test_no_false_positive_when_loading_single_object_generic_relation():
+    from djangoproject.social.models import Tag
+
+    user_1, user_2 = UserFactory.create_batch(2)
+    Tag.objects.create(obj=user_1, label="a")
+    Tag.objects.create(obj=user_2, label="b")
+
+    with zeal_context(), CaptureQueriesContext(connection) as ctx:
+        user_1 = User.objects.filter(pk=user_1.pk).first()
+        user_2 = User.objects.filter(pk=user_2.pk).first()
+        assert user_1 is not None and user_2 is not None
+        _ = list(user_1.tags.all())
+        _ = list(user_2.tags.all())
+        assert len(ctx.captured_queries) == 4
+
+    with zeal_context(), CaptureQueriesContext(connection) as ctx:
+        user_1 = User.objects.filter(pk=user_1.pk)[0]
+        user_2 = User.objects.filter(pk=user_2.pk)[0]
+        _ = list(user_1.tags.all())
+        _ = list(user_2.tags.all())
+        assert len(ctx.captured_queries) == 4
+
+    with zeal_context(), CaptureQueriesContext(connection) as ctx:
+        user_1 = User.objects.get(pk=user_1.pk)
+        user_2 = User.objects.get(pk=user_2.pk)
+        _ = list(user_1.tags.all())
+        _ = list(user_2.tags.all())
+        assert len(ctx.captured_queries) == 4

--- a/tests/test_nplusones.py
+++ b/tests/test_nplusones.py
@@ -627,3 +627,19 @@ def test_detects_nplusone_in_generic_relation():
 
     for user in User.objects.prefetch_related("tags").all():
         _ = list(user.tags.all())
+
+
+def test_detects_nplusone_in_generic_relation_iterator():
+    from djangoproject.social.models import Tag
+
+    for _ in range(4):
+        user = UserFactory.create()
+        Tag.objects.create(obj=user, label="x")
+    with pytest.raises(
+        NPlusOneError, match=re.escape("N+1 detected on social.User.tags")
+    ):
+        for user in User.objects.all().iterator(chunk_size=2):
+            _ = list(user.tags.all())
+
+    for user in User.objects.prefetch_related("tags").iterator(chunk_size=2):
+        _ = list(user.tags.all())


### PR DESCRIPTION
## Summary

Closes #66.

This PR adds N+1 detection on GenericRelation fields.

I added a Tag model to use for the tests.