### PR TITLE
feat: detect N+1 on forward GenericForeignKey access

### DIFF
--- a/src/zeal/patch.py
+++ b/src/zeal/patch.py
@@ -36,6 +36,13 @@ _in_prefetch_queryset: ContextVar[bool] = ContextVar(
     "_in_prefetch_queryset", default=False
 )
 
+# Set to True while resolving a GenericForeignKey via __get__.
+# Suppresses the QuerySet.get notification fired by the
+# internal ContentType.get_object_for_this_type() call,
+# so the N+1 is reported on the parent model's GFK field
+# instead of on the resolved model's .get().
+_in_gfk_get: ContextVar[bool] = ContextVar("_in_gfk_get", default=False)
+
 
 class QuerysetContext(TypedDict):
     args: Optional[Any]
@@ -387,6 +394,29 @@ def patch_many_to_many_descriptor():
     )
 
 
+def patch_generic_foreign_key():
+    from django.contrib.contenttypes.fields import GenericForeignKey
+
+    original_get = GenericForeignKey.__get__
+
+    def patched_get(self, instance, cls=None):
+        if instance is None:
+            return original_get(self, instance, cls)
+        if not self.is_cached(instance):
+            n_plus_one_listener.notify(
+                instance.__class__,
+                self.name,
+                instance_key=get_instance_key(instance),
+            )
+        token = _in_gfk_get.set(True)
+        try:
+            return original_get(self, instance, cls)
+        finally:
+            _in_gfk_get.reset(token)
+
+    GenericForeignKey.__get__ = patched_get  # type: ignore
+
+
 def patch_generic_related_manager():
     from django.contrib.contenttypes.fields import (
         create_generic_related_manager,
@@ -495,8 +525,13 @@ def patch_global_queryset():
         def wrapper(*args, **kwargs):
             qs = args[0]
             # Detect N+1 on standalone .get() calls (e.g. in a loop).
-            # Skip if the queryset is already tracked via a relation descriptor.
-            if not getattr(qs, "__zeal_patched", False):
+            # Skip if the queryset is already tracked via a relation descriptor,
+            # or if we're resolving a GenericForeignKey (its own patch reports
+            # the N+1 on the parent model's GFK field instead).
+            if (
+                not getattr(qs, "__zeal_patched", False)
+                and not _in_gfk_get.get()
+            ):
                 n_plus_one_listener.notify(qs.model, "get", instance_key=None)
             ret = func(*args, **kwargs)
             n_plus_one_listener.ignore(get_instance_key(ret))
@@ -538,6 +573,7 @@ def patch():
     patch_reverse_many_to_one_descriptor()
     patch_reverse_one_to_one_descriptor()
     patch_many_to_many_descriptor()
+    patch_generic_foreign_key()
     patch_generic_related_manager()
     patch_deferred_attribute()
     patch_global_queryset()

--- a/src/zeal/patch.py
+++ b/src/zeal/patch.py
@@ -399,10 +399,17 @@ def patch_generic_foreign_key():
 
     original_get = GenericForeignKey.__get__
 
+    def _would_hit_db(gfk, instance) -> bool:
+        if gfk.is_cached(instance):
+            return False
+        # When ct_id is None, __get__ short-circuits without a query.
+        ct_attname = instance._meta.get_field(gfk.ct_field).get_attname()
+        return getattr(instance, ct_attname, None) is not None
+
     def patched_get(self, instance, cls=None):
         if instance is None:
             return original_get(self, instance, cls)
-        if not self.is_cached(instance):
+        if _would_hit_db(self, instance):
             n_plus_one_listener.notify(
                 instance.__class__,
                 self.name,

--- a/tests/djangoproject/social/models.py
+++ b/tests/djangoproject/social/models.py
@@ -41,6 +41,8 @@ class Post(models.Model):
 
 class Tag(models.Model):
     label = models.TextField()
-    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
-    object_id = models.PositiveIntegerField()
+    content_type = models.ForeignKey(
+        ContentType, on_delete=models.CASCADE, null=True, blank=True
+    )
+    object_id = models.PositiveIntegerField(null=True, blank=True)
     obj = GenericForeignKey()

--- a/tests/test_nplusones.py
+++ b/tests/test_nplusones.py
@@ -712,3 +712,94 @@ def test_no_false_positive_when_calling_generic_relation_twice():
         list(queryset)  # evaluate queryset once
         list(queryset)  # evaluate again (cached)
         assert len(ctx.captured_queries) == 1
+
+
+def test_detects_nplusone_in_generic_foreign_key():
+    from djangoproject.social.models import Tag
+
+    [user_1, user_2] = UserFactory.create_batch(2)
+    Tag.objects.create(obj=user_1, label="a")
+    Tag.objects.create(obj=user_2, label="b")
+    with pytest.raises(
+        NPlusOneError, match=re.escape("N+1 detected on social.Tag.obj")
+    ):
+        for tag in Tag.objects.all():
+            _ = tag.obj
+
+    for tag in Tag.objects.prefetch_related("obj").all():
+        _ = tag.obj
+
+
+def test_detects_nplusone_in_generic_foreign_key_iterator():
+    from djangoproject.social.models import Tag
+
+    for _ in range(4):
+        user = UserFactory.create()
+        Tag.objects.create(obj=user, label="x")
+    with pytest.raises(
+        NPlusOneError, match=re.escape("N+1 detected on social.Tag.obj")
+    ):
+        for tag in Tag.objects.all().iterator(chunk_size=2):
+            _ = tag.obj
+
+    for tag in Tag.objects.prefetch_related("obj").iterator(chunk_size=2):
+        _ = tag.obj
+
+
+def test_no_false_positive_when_loading_single_object_generic_foreign_key():
+    from djangoproject.social.models import Tag
+
+    user_1, user_2 = UserFactory.create_batch(2)
+    tag_1 = Tag.objects.create(obj=user_1, label="a")
+    tag_2 = Tag.objects.create(obj=user_2, label="b")
+
+    with zeal_context():
+        tag_1 = Tag.objects.filter(pk=tag_1.pk).first()
+        tag_2 = Tag.objects.filter(pk=tag_2.pk).first()
+        assert tag_1 is not None and tag_2 is not None
+        _ = tag_1.obj
+        _ = tag_2.obj
+
+    with zeal_context():
+        tag_1 = Tag.objects.filter(pk=tag_1.pk)[0]
+        tag_2 = Tag.objects.filter(pk=tag_2.pk)[0]
+        _ = tag_1.obj
+        _ = tag_2.obj
+
+    with zeal_context():
+        tag_1 = Tag.objects.get(pk=tag_1.pk)
+        tag_2 = Tag.objects.get(pk=tag_2.pk)
+        _ = tag_1.obj
+        _ = tag_2.obj
+
+
+def test_zeal_ignore_works_for_generic_foreign_key():
+    from djangoproject.social.models import Tag
+
+    [user_1, user_2] = UserFactory.create_batch(2)
+    Tag.objects.create(obj=user_1, label="a")
+    Tag.objects.create(obj=user_2, label="b")
+
+    with zeal_ignore([{"model": "social.Tag", "field": "obj"}]):
+        for tag in Tag.objects.all():
+            _ = tag.obj
+
+
+def test_no_false_positive_when_accessing_generic_foreign_key_twice():
+    from djangoproject.social.models import Tag
+
+    user = UserFactory.create()
+    Tag.objects.create(obj=user, label="a")
+
+    with zeal_context(), CaptureQueriesContext(connection) as ctx:
+        [tag] = list(Tag.objects.all())
+        _ = tag.obj  # first access hits DB
+        _ = tag.obj  # second access uses descriptor cache
+        # 1 query for the tag itself, 1 for the User via GFK,
+        # plus ContentType lookups (cached after first).
+        gfk_queries = [
+            q
+            for q in ctx.captured_queries
+            if '"social_user"' in q["sql"]
+        ]
+        assert len(gfk_queries) == 1

--- a/tests/test_nplusones.py
+++ b/tests/test_nplusones.py
@@ -785,6 +785,19 @@ def test_zeal_ignore_works_for_generic_foreign_key():
             _ = tag.obj
 
 
+def test_no_false_positive_when_generic_foreign_key_is_null():
+    from djangoproject.social.models import Tag
+
+    Tag.objects.create(label="a")
+    Tag.objects.create(label="b")
+
+    with zeal_context(), CaptureQueriesContext(connection) as ctx:
+        for tag in Tag.objects.all():
+            assert tag.obj is None
+        # Only the SELECT for Tag.objects.all(); no per-row GFK queries.
+        assert len(ctx.captured_queries) == 1
+
+
 def test_no_false_positive_when_accessing_generic_foreign_key_twice():
     from djangoproject.social.models import Tag
 


### PR DESCRIPTION
Forward `GenericForeignKey` access in a loop now reports `N+1 detected on social.Tag.obj` instead of misattributing it to the resolved model's `.get()` (e.g. `social.User.get`). 