### PR TITLE
fix: allow pickling of related/prefetched querysets (#76)

### DIFF
--- a/src/zeal/patch.py
+++ b/src/zeal/patch.py
@@ -573,10 +573,22 @@ def patch_global_queryset():
     # pickle query results (e.g. django-cacheops), even outside an active
     # zeal context, because the attributes are attached at creation time.
     #
-    # The zeal attributes are safely reconstructible: an unpickled queryset
-    # falls back to the (still-patched) class-level methods, and accessing a
-    # relation re-patches fresh querysets via the descriptor patches. So we
-    # simply strip them from the pickled state.
+    # The zeal attributes are safely reconstructible for the motivating use
+    # case (pickling evaluated querysets / model instances carrying a
+    # prefetched cache): an unpickled queryset falls back to the (still-
+    # patched) class-level methods, and accessing a relation re-patches
+    # fresh querysets via the descriptor patches. Django also pre-evaluates
+    # querysets in ``__getstate__``, so the ``_fetch_all`` notify guard
+    # (``_result_cache is None``) never fires on the unpickled queryset
+    # itself. So we simply strip them from the pickled state.
+    #
+    # Known tradeoff: N+1 detection is NOT preserved on querysets *derived*
+    # from a roundtripped related queryset (e.g.
+    # ``pickle.loads(dumps(user.posts.all())).filter(...)``), because the
+    # per-instance ``_clone`` re-patching chain is gone. This is an unusual
+    # pattern outside the cacheops scope; preserving it would require a
+    # picklable relation-tracking marker plus class-level ``_clone``/
+    # ``_fetch_all`` dispatch, touching the hot path of every queryset.
     # https://github.com/taobojlen/django-zeal/issues/76
     original_getstate = QuerySet.__getstate__
     _zeal_pickle_keys = (

--- a/src/zeal/patch.py
+++ b/src/zeal/patch.py
@@ -565,6 +565,35 @@ def patch_global_queryset():
         patched_prefetch_related_objects
     )
 
+    # zeal attaches per-queryset closures to ``_clone``/``_fetch_all`` (and
+    # marks querysets with ``__zeal_patched``/``__zeal_skip_notify``) as
+    # *instance* attributes. Local closures have no importable qualname, so
+    # pickle -- which walks ``__dict__`` -- crashes on any queryset that went
+    # through a patched relation/prefetch path. This breaks libraries that
+    # pickle query results (e.g. django-cacheops), even outside an active
+    # zeal context, because the attributes are attached at creation time.
+    #
+    # The zeal attributes are safely reconstructible: an unpickled queryset
+    # falls back to the (still-patched) class-level methods, and accessing a
+    # relation re-patches fresh querysets via the descriptor patches. So we
+    # simply strip them from the pickled state.
+    # https://github.com/taobojlen/django-zeal/issues/76
+    original_getstate = QuerySet.__getstate__
+    _zeal_pickle_keys = (
+        "_clone",
+        "_fetch_all",
+        "__zeal_patched",
+        "__zeal_skip_notify",
+    )
+
+    def patched_getstate(self):
+        state = original_getstate(self)
+        for key in _zeal_pickle_keys:
+            state.pop(key, None)
+        return state
+
+    QuerySet.__getstate__ = patched_getstate  # type: ignore
+
     from django.db.models import query as _query_module
 
     original_module_prefetch = _query_module.prefetch_related_objects

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,0 +1,96 @@
+"""
+Regression tests for https://github.com/taobojlen/django-zeal/issues/76
+
+zeal attaches locally-defined closures to queryset instances
+(``_clone``/``_fetch_all``/``__zeal_patched``). Local closures are not
+picklable, so any related or prefetched queryset created while zeal is
+installed can no longer be pickled -- even outside an active zeal context.
+
+These tests must pass both with and without an active zeal context, because
+the issue is caused by merely having zeal in INSTALLED_APPS.
+"""
+
+import pickle
+
+import pytest
+from djangoproject.social.models import User
+
+from .factories import PostFactory, UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _roundtrip(qs):
+    return pickle.loads(pickle.dumps(qs))
+
+
+def test_plain_queryset_pickles():
+    """A plain queryset (no zeal-affected path) must pickle."""
+    UserFactory.create()
+    qs = User.objects.all()
+    assert _roundtrip(qs).count() == 1
+
+
+def test_prefetch_related_queryset_pickles():
+    """
+    `prefetch_related` produces querysets that go through zeal's patched
+    prefetch path. The resulting (un-evaluated) queryset must pickle.
+    """
+    user = UserFactory.create()
+    PostFactory.create(author=user)
+
+    qs = User.objects.prefetch_related("posts")
+    assert _roundtrip(qs).count() == 1
+
+
+def test_reverse_fk_queryset_pickles():
+    """A reverse FK manager's queryset (user.posts.all()) must pickle."""
+    user = UserFactory.create()
+    PostFactory.create(author=user)
+
+    qs = user.posts.all()
+    assert _roundtrip(qs).count() == 1
+
+
+def test_m2m_queryset_pickles():
+    """A M2M manager's queryset (user.following.all()) must pickle."""
+    u1 = UserFactory.create()
+    u2 = UserFactory.create()
+    u1.following.add(u2)
+
+    qs = u1.following.all()
+    assert _roundtrip(qs).count() == 1
+
+
+def test_prefetched_instance_pickles_with_cache():
+    """
+    The cacheops scenario: a model instance carrying a prefetched queryset in
+    ``_prefetched_objects_cache`` is pickled as part of a larger object graph.
+    This must not crash.
+    """
+    user = UserFactory.create()
+    PostFactory.create(author=user)
+    PostFactory.create(author=user)
+
+    [loaded] = list(User.objects.prefetch_related("posts"))
+    # Force the prefetch cache population by accessing the relation.
+    posts = list(loaded.posts.all())
+    assert len(posts) == 2
+
+    restored = pickle.loads(pickle.dumps(loaded))
+    # prefetched data survives the round-trip
+    assert {p.pk for p in restored.posts.all()} == {p.pk for p in posts}
+
+
+@pytest.mark.nozeal
+def test_pickles_work_without_zeal_context():
+    """
+    The issue reproduces regardless of whether a zeal context is active,
+    because the instance attributes are attached at queryset creation time.
+    Ensure pickling works with no active context.
+    """
+    user = UserFactory.create()
+    PostFactory.create(author=user)
+
+    qs = User.objects.prefetch_related("posts")
+    assert _roundtrip(qs).count() == 1

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -13,6 +13,8 @@ the issue is caused by merely having zeal in INSTALLED_APPS.
 import pickle
 
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from djangoproject.social.models import User
 
 from .factories import PostFactory, UserFactory
@@ -66,7 +68,8 @@ def test_prefetched_instance_pickles_with_cache():
     """
     The cacheops scenario: a model instance carrying a prefetched queryset in
     ``_prefetched_objects_cache`` is pickled as part of a larger object graph.
-    This must not crash.
+    This must not crash, and the prefetched data must actually survive the
+    round-trip (not be silently reloaded from the database on access).
     """
     user = UserFactory.create()
     PostFactory.create(author=user)
@@ -76,10 +79,19 @@ def test_prefetched_instance_pickles_with_cache():
     # Force the prefetch cache population by accessing the relation.
     posts = list(loaded.posts.all())
     assert len(posts) == 2
+    expected_pks = {p.pk for p in posts}
 
     restored = pickle.loads(pickle.dumps(loaded))
-    # prefetched data survives the round-trip
-    assert {p.pk for p in restored.posts.all()} == {p.pk for p in posts}
+
+    # The prefetch cache must survive serialization. Asserting on the cache
+    # directly (and that accessing the restored relation issues zero queries)
+    # guards against a regression where the data happens to match only because
+    # ``.all()`` reloaded the same rows from the database.
+    assert "posts" in restored._prefetched_objects_cache
+    with CaptureQueriesContext(connection) as captured:
+        result = list(restored.posts.all())
+    assert len(captured.captured_queries) == 0
+    assert {p.pk for p in result} == expected_pks
 
 
 @pytest.mark.nozeal


### PR DESCRIPTION
## Summary

zeal attached locally-defined closures to queryset instances (`_clone`/`_fetch_all`) as instance attributes. Local closures have no importable qualname, so `pickle` — which walks `__dict__` — crashed on any queryset that went through a patched relation/prefetch path:

```
AttributeError: Can't pickle local object 'patch_queryset_function.<locals>.wrapper'
```

This broke libraries that pickle query results (e.g. [django-cacheops](https://github.com/Suor/django-cacheops) storing prefetched querysets in Redis), **even outside an active zeal context** — simply having `zeal` in `INSTALLED_APPS` was enough, because the attributes are attached unconditionally at queryset creation time.

Closes #76.


